### PR TITLE
add newrelic_agent::newrelic_plugin_agent

### DIFF
--- a/manifests/newrelic_plugin_agent.pp
+++ b/manifests/newrelic_plugin_agent.pp
@@ -1,0 +1,114 @@
+# This manages the newrelic-plugin-agent process from 
+# https://github.com/MeetMe/newrelic-plugin-agent
+#
+# Requires the main newrelic_agent class to provide the license key
+#
+# Most of this is based on https://github.com/rlex/puppet-newrelic_plugin_agent
+#
+# === Parameters
+#
+# [*epel_repo_name*]
+#   Default: epel
+#   Name of EPEL yum repository
+#
+# [*newrelic_api_timeout*]
+#   Default: 10 seconds
+#   How long to wait for NewRelic API calls
+#
+# [*wake_interval*]
+#   Default: 60 seconds
+#   How often to send data
+#
+# [*manage_svc*]
+#   Default: True
+#   Allow for disabling the management of the agent service via puppet
+#
+# [*manage_pkg*]
+#   Default: True
+#   Allow for overriding the package management of this module
+#
+# [*service_ensure*]
+#   Default: running
+#   Override the default state of the service
+#
+# [*proxy*]
+#   Default: undef
+#   If a proxy is required to reach the NewRelic API
+#
+# [*pidfile*]
+#   Default: /var/run/newrelic/newrelic-plugin-agent.pid
+#   Full path to the PID file
+#
+# [*version*]
+#   Default: installed
+#   Specify a specific version of the newrelic-plugin-agent python package
+#
+class newrelic_agent::newrelic_plugin_agent (
+  $epel_repo_name = 'epel',
+  $newrelic_api_timeout = '10',
+  $wake_interval = '60',
+  $manage_svc = true,
+  $manage_pkg = true,
+  $service_ensure = 'running',
+  $user = 'newrelic',
+  $proxy = undef,
+  $pidfile = '/var/run/newrelic/newrelic-plugin-agent.pid',
+  $version = 'installed',
+) {
+  validate_bool($manage_pkg)
+  validate_bool($manage_svc)
+
+  # Resource ordering, this module depends on the main newrelic_agent class.
+  Class['newrelic_agent'] -> Class['newrelic_agent::newrelic_plugin_agent']
+
+  $license_key = $::newrelic_agent::newrelic_license_key
+
+  package { 'python-pip':
+    ensure => installed,
+    require => Yumrepo[$epel_repo_name],
+  }
+
+  if ($manage_pkg) {
+    package { 'newrelic-plugin-agent':
+      ensure   => $version,
+      provider => 'pip',
+      require  => Package['python-pip'],
+    }
+  }
+
+  file { '/etc/init.d/newrelic-plugin-agent':
+    content => template('newrelic_agent/newrelic_plugin_agent/newrelic-plugin-agent.init'),
+    mode    => '0755',
+  }
+
+  if ($manage_svc) {
+    service { 'newrelic-plugin-agent':
+      enable  => true,
+      ensure  => $service_ensure,
+      require => [ Package['newrelic-plugin-agent'],
+                   File['/etc/init.d/newrelic-plugin-agent'],
+                   Concat['/etc/newrelic/newrelic-plugin-agent.cfg'],
+                 ],
+    }
+  }
+
+  include concat::setup
+
+  concat::fragment { 'newrelic_plugin_agent-header':
+    order   => '01',
+    target  => '/etc/newrelic/newrelic-plugin-agent.cfg',
+    content => template('newrelic_agent/newrelic_plugin_agent/newrelic-plugin-agent-header.cfg.erb'),
+    require => Package['newrelic-plugin-agent'],
+  }
+
+  concat::fragment { 'newrelic_plugin_agent-footer':
+    order   => '99',
+    target  => '/etc/newrelic/newrelic-plugin-agent.cfg',
+    content => template('newrelic_agent/newrelic_plugin_agent/newrelic-plugin-agent-footer.cfg.erb'),
+    require => Package['newrelic-plugin-agent'],
+  }
+
+  concat { '/etc/newrelic/newrelic-plugin-agent.cfg':
+    notify  => Service['newrelic-plugin-agent'],
+  }
+}

--- a/manifests/newrelic_plugin_agent/mongodb.pp
+++ b/manifests/newrelic_plugin_agent/mongodb.pp
@@ -1,0 +1,76 @@
+# This manages the mongodb requirements for newrelic-plugin-agent
+#
+# === Parameters
+#
+# [*host*]
+#   Default: localhost
+#   Host where the mongodb instance is running
+#
+# [*port*]
+#   Default: 27017
+#   Port the mongodb instance is listening on
+#
+# [*ssl*]
+#   Default: false
+#   If the mongodb instance is requires SSL
+#
+# [*admin_username*]
+#   Default: undef
+#   If the mongodb instance requires an admin username
+#
+# [*admin_password*]
+#   Default: undef
+#   If the mongodb instance requires an admin password
+#
+# [*ssl_keyfile*]
+#   Default: undef
+#   Path to keyfile
+#
+# [*ssl_certfile*]
+#   Default: undef
+#   Path to certfile
+#
+# [*ssl_cert_reqs*]
+#   Default: 0
+#   0 for ssl.CERT_NONE, 1 for ssl.CERT_OPTIONAL, 2 for ssl.CERT_REQUIRED
+#
+# [*ssl_ca_certs*]
+#   Default: undef
+#   Path to cacerts file
+#
+# === Settings
+#
+# [*databases*]
+#   Default: undef
+#   Type: Array
+#   Databases names to gather metrics
+#
+#   Example:
+#     $databases = ['db1', 'db2']
+#
+define newrelic_agent::newrelic_plugin_agent::mongodb (
+  $host = 'localhost',
+  $port = '27017',
+  $ssl = false,
+  $admin_username = undef,
+  $admin_password = undef,
+  $ssl_keyfile = undef,
+  $ssl_certfile = undef,
+  $ssl_cert_reqs = '0',
+  $ssl_ca_certs = undef,
+  $databases = undef,
+) {
+  validate_bool($ssl)
+  validate_array($databases)
+
+  package { ['python-devel', 'python-pymongo']:
+    ensure => present,
+    before => Package['newrelic-plugin-agent'],
+  }
+
+  concat::fragment { "newrelic_plugin_agent-mongodb-${name}":
+    order   => '07',
+    target  => '/etc/newrelic/newrelic-plugin-agent.cfg',
+    content => template('newrelic_agent/newrelic_plugin_agent/mongodb.erb'),
+  }
+}

--- a/manifests/newrelic_plugin_agent/mongodb_instance.pp
+++ b/manifests/newrelic_plugin_agent/mongodb_instance.pp
@@ -1,0 +1,5 @@
+# newrelic_agent::newrelic_plugin_agent::mongodb_instance
+class newrelic_agent::newrelic_plugin_agent::mongodb_instance ($instance) {
+  $real_instance = hiera_hash(newrelic_agent::newrelic_plugin_agent::mongodb_instance::instance)
+  create_resources(newrelic_agent::newrelic_plugin_agent::mongodb, $real_instance)
+}

--- a/templates/newrelic_plugin_agent/mongodb.erb
+++ b/templates/newrelic_plugin_agent/mongodb.erb
@@ -1,0 +1,29 @@
+  mongodb:
+    name: <%= "#{@name}" %>
+    host: <%= "#{@host}" %>
+    port: <%= "#{@port}" %>
+    ssl: <%= "#{@ssl}" %>
+<% if @admin_username -%>
+<%= "    admin_username: #{@admin_username}" %>
+<% end -%>
+<% if @admin_password -%>
+<%= "    admin_password: #{@admin_password}" %>
+<% end -%>
+<% if @ssl_cert_reqs != '0' -%>
+<%= "    ssl_keyfile: #{@ssl_keyfile}" %>
+<% end -%>
+<% if @ssl_cert_reqs != '0' -%>
+<%= "    ssl_certfile: #{@ssl_certfile}" %>
+<% end -%>
+<% if @ssl_cert_reqs != '0' -%>
+<%= "    port: #{@ssl_cert_reqs}" %>
+<% end -%>
+<% if @ssl_cert_reqs != '0' -%>
+<%= "    ssl_ca_certs: #{@ssl_ca_certs}" %>
+<% end -%>
+<% if @databases -%>
+<%= "    databases:" %>
+<% [@databases].flatten.compact.each do |database| -%>
+<%= "      - #{database}" %>
+<% end -%>
+<% end -%>

--- a/templates/newrelic_plugin_agent/newrelic-plugin-agent-footer.cfg.erb
+++ b/templates/newrelic_plugin_agent/newrelic-plugin-agent-footer.cfg.erb
@@ -1,0 +1,25 @@
+
+Daemon:
+  user: <%= @user %>
+  pidfile: <%= @pidfile %>
+
+Logging:
+  formatters:
+    verbose:
+      format: '%(levelname) -10s %(asctime)s %(process)-6d %(processName) -15s %(threadName)-10s %(name) -45s %(funcName) -25s L%(lineno)-6d: %(message)s'
+  handlers:
+    file:
+      class : logging.handlers.RotatingFileHandler
+      formatter: verbose
+      filename: /var/log/newrelic/newrelic-plugin-agent.log
+      maxBytes: 10485760
+      backupCount: 3
+  loggers:
+    newrelic_plugin_agent:
+      level: INFO
+      propagate: True
+      handlers: [console, file]
+    requests:
+      level: ERROR
+      propagate: True
+      handlers: [console, file]

--- a/templates/newrelic_plugin_agent/newrelic-plugin-agent-header.cfg.erb
+++ b/templates/newrelic_plugin_agent/newrelic-plugin-agent-header.cfg.erb
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+Application:
+  license_key: <%= "#{@license_key}" %>
+  wake_interval: <%= "#{@wake_interval}" %>
+  newrelic_api_timeout: <%= "#{@newrelic_api_timeout}" %>
+<% if @proxy -%>
+<%= "  proxy: #{@proxy}" %>
+<% end -%>
+

--- a/templates/newrelic_plugin_agent/newrelic-plugin-agent.init
+++ b/templates/newrelic_plugin_agent/newrelic-plugin-agent.init
@@ -1,0 +1,131 @@
+#!/bin/bash
+# chkconfig: 2345 99 60
+# description: newrelic-plugin-agent
+# processname: newrelic-plugin-agent
+# config: /etc/sysconfig/newrelic-plugin-agent
+# pidfile: /var/run/newrelic-plugin-agent.pid
+
+# Source function library.
+. /etc/init.d/functions
+
+# Application
+APP="/usr/bin/newrelic-plugin-agent"
+
+# Configuration dir
+CONFIG_DIR="/etc/newrelic"
+
+# PID File
+PID_FILE="/var/run/newrelic/newrelic-plugin-agent.pid"
+
+# Additional arguments
+OPTS=""
+
+if [ -f /etc/sysconfig/newrelic-plugin-agent ]; then
+  # Include configuration
+  . /etc/sysconfig/newrelic-plugin-agent
+fi
+
+# Configuration file
+CONF="${CONF:-${CONFIG_DIR}/newrelic-plugin-agent.cfg}"
+
+if [ ! -f "${CONF}" ]; then
+  echo -n $"cannot find newrelic-plugin-agent configuration file: '${CONF}'"
+  failure $"cannot find newrelic-plugin-agent configuration file: '${CONF}'"
+  echo
+  exit 1
+fi
+
+OPTS="-c ${CONF} ${OPTS}"
+
+dostatus() {
+  [ -e "${PID_FILE}" ] || return 1
+
+  local pid=$(cat ${PID_FILE})
+  [ -d /proc/${pid} ] || return 1
+
+  [ -z "$(grep $APP /proc/${pid}/cmdline)" ] && return 1
+  return 0
+}
+
+start() {
+  if [ ${EUID} -ne 0 ]; then
+    echo -n $"you must be root"
+    failure $"you must be root"
+    echo
+    return 1
+  fi
+
+  echo -n $"Starting ${APP}: "
+
+  dostatus
+  if [ $? -eq 0 ]; then
+    echo -n $"cannot start $APP: already running (pid: $(cat ${PID_FILE}))";
+    failure $"cannot start $APP: already running (pid: $(cat ${PID_FILE}))";
+    echo
+    return 1
+  fi
+
+  ${APP} ${OPTS} && success || failure
+  RETVAL=$?
+
+  echo
+  return ${RETVAL}
+}
+
+stop() {
+  if [ ${EUID} -ne 0 ]; then
+    echo -n $"you must be root"
+    failure $"you must be root"
+    echo
+    return 1
+  fi
+
+  echo -n $"Stopping ${APP}: "
+
+  dostatus
+  if [ $? -ne 0 ]; then
+    echo -n $"cannot stop $APP: not running"
+    failure $"cannot stop $APP: not running"
+    echo
+    return 1
+  fi
+
+  killproc -p "${PID_FILE}" "${APP}"
+  RETVAL=$?
+  [ $RETVAL -eq 0 ] && rm -f ${PID_FILE}
+  echo
+  return $RETVAL
+}
+
+restart() {
+  stop
+  start
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    restart
+    ;;
+  status)
+    dostatus
+    if [ $? -eq 0 ]; then
+      echo $"$APP: running"
+      RETVAL=0
+    else
+      echo $"$APP: not running"
+      RETVAL=1
+    fi
+    ;;
+  *)
+    echo $"Usage: $0 {start|stop|status|restart}"
+    RETVAL=2
+    ;;
+esac
+
+exit $RETVAL


### PR DESCRIPTION
These changes add
newrelic_agent::newrelic_plugin_agent class
newrelic_agent::newrelic_plugin_agent::mongodb define
newrelic_agent::newrelic_plugin_agent::mongodb_instance wrapper

These changes are based on https://github.com/rlex/puppet-newrelic_plugin_agent
which unfortunately does not fit our use case.

https://github.com/MeetMe/newrelic-plugin-agent is a python application that
supports the following backends:

* Alternative PHP Cache
* Apache HTTP Server
* CouchDB
* Elasticsearch
* HAProxy
* Memcached
* MongoDB
* Nginx
* pgBouncer
* PHP FPM
* PostgreSQL
* RabbitMQ
* Redis
* Riak
* uWSGI

These changes only add support for managing mongodb, but we can add others
in the future.