### PR TITLE
Add support for machine labels

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,9 @@
 #   This is the license key for your NewRelic account and must be provided for
 #   this module to work.
 #
+# [*sysmond_labels*]
+#   Array of labels to apply to the machine
+#
 # === Examples
 #
 #  This will install the newrelic sysmond agent using the default settings and
@@ -100,6 +103,7 @@ class newrelic_agent (
   $sysmond_ssl_ca_bundle = undef,
   $sysmond_ssl_ca_path = undef,
   $sysmond_timeout = '30',
+  $sysmond_labels = undef,
 ) {
   validate_string($newrelic_license_key)
   validate_string($sysmond_pkg)

--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -139,3 +139,14 @@ collector_host=<%= @sysmond_collector_host %>
 #
 #timeout=30
 timeout=<%= @sysmond_timeout %>
+
+#
+# Option : labels
+# Value  : A dictionary of label names and values for categories that will be
+#          applied to the data sent from this agent. This may also be expressed
+#          as a semicolon delimited string of colon-separated pairs.
+#          #For example: labels=Server:One;Data Center:Primary;
+# Default: ""
+<% if @sysmond_labels -%>
+labels=<%= @sysmond_labels.join(';') %>;
+<% end -%>


### PR DESCRIPTION
Adding support for labels: https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/configuring-servers-linux#configuration-settings